### PR TITLE
fix: google material iconsを使えるようにした

### DIFF
--- a/src/components/KosmoTimeTaskCard.tsx
+++ b/src/components/KosmoTimeTaskCard.tsx
@@ -7,7 +7,9 @@ const  KosmoTimeTaskCard = () => {
       <div>
         <button>再生アイコン</button>
         <div>
-          <span>砂時計アイコン</span>
+          <span className="material-icons">
+            hourglass_top
+          </span>
           <span>00:00:00</span>
         </div>
       </div>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,10 +1,14 @@
 import { GlobalStyles } from '@/styles/Globals';
 import type { AppProps } from 'next/app';
+import Head from 'next/head'
 import React from 'react';
 
 function MyApp({ Component, pageProps }: AppProps): JSX.Element {
   return (
     <>
+      <Head>
+        <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+      </Head>
       <GlobalStyles />
       <Component {...pageProps} />
     </>


### PR DESCRIPTION
https://fonts.google.com/icons?selected=Material+Icons
https://developers.google.com/fonts/docs/material_icons
https://qiita.com/MASA-JAPAN/items/3551c070e7386df87d18
